### PR TITLE
Add skip_latest_tag input to build workflow

### DIFF
--- a/.github/workflows/build-minio.yml
+++ b/.github/workflows/build-minio.yml
@@ -15,6 +15,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_latest_tag:
+        description: 'Skip tagging as latest (useful for building older versions)'
+        required: false
+        type: boolean
+        default: false
 
 env:
   GITHUB_REGISTRY: ghcr.io
@@ -178,19 +183,31 @@ jobs:
 
       - name: Create & publish manifest on ${{ env.GITHUB_REGISTRY }}
         run: |
+          TAGS="-t ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}"
+          TAGS="$TAGS -t ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.clean_version }}"
+
+          # Only add latest tag if skip_latest_tag is false
+          if [ "${{ github.event.inputs.skip_latest_tag }}" != "true" ]; then
+            TAGS="$TAGS -t ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          fi
+
           docker buildx imagetools create \
-          -t ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }} \
-          -t ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.clean_version }} \
-          -t ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+          $TAGS \
           ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}-amd64 \
           ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}-arm64
 
       - name: Create & publish manifest on ${{ env.DOCKER_REGISTRY }}
         run: |
+          TAGS="-t ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}"
+          TAGS="$TAGS -t ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.clean_version }}"
+
+          # Only add latest tag if skip_latest_tag is false
+          if [ "${{ github.event.inputs.skip_latest_tag }}" != "true" ]; then
+            TAGS="$TAGS -t ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          fi
+
           docker buildx imagetools create \
-          -t ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }} \
-          -t ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.clean_version }} \
-          -t ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+          $TAGS \
           ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}-amd64 \
           ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}-arm64
 


### PR DESCRIPTION
## Background
Users need the ability to build specific older image versions without overwriting the `:latest` tag. This is useful for CI/CD scenarios where specific historical builds need to be preserved.

## Changes
- `.github/workflows/build-minio.yml`:
  - Added a new boolean input `skip_latest_tag` which defaults to `false`.
  - Modified the `docker buildx imagetools create` commands for both GITHUB_REGISTRY and DOCKER_REGISTRY.
  - The `:latest` tag is now conditionally added to the manifest only if `skip_latest_tag` is not `true`.

## Testing
- [ ] Manually trigger the build workflow and set `skip_latest_tag` to `true`. Verify that the `:latest` tag is NOT applied to the created manifest.
- [ ] Manually trigger the build workflow and leave `skip_latest_tag` unset (defaults to `false`). Verify that the `:latest` tag IS applied to the created manifest.
- [ ] Ensure version-specific tags (e.g., `version` and `clean_version`) are always applied.
