### PR TITLE
feat: Use matrix builds and github-hosted runner for arm64 builds

### DIFF
--- a/.github/workflows/build-minio.yml
+++ b/.github/workflows/build-minio.yml
@@ -73,15 +73,22 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-  amd64:
-    runs-on: ubuntu-latest
+  build-push:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     needs: check-release
     if: needs.check-release.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -100,64 +107,23 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and Push Image (amd64)
+      - name: Build and Push Image (${{ matrix.arch }})
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/${{ matrix.arch }}
           push: true
           build-args: |
             MINIO_VERSION=${{ needs.check-release.outputs.version }}
           tags: |
-            ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}-amd64
-            ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}-amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  aarch64:
-    runs-on: [ self-hosted, arm64 ]
-    needs: check-release
-    if: needs.check-release.outputs.should_build == 'true'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to ${{ env.GITHUB_REGISTRY }}
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GITHUB_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to ${{ env.DOCKER_REGISTRY }}
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and Push Image (aarch64)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/arm64
-          push: true
-          build-args: |
-            MINIO_VERSION=${{ needs.check-release.outputs.version }}
-          tags: |
-            ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}-arm64
-            ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}-arm64
+            ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}-${{ matrix.arch }}
+            ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-release.outputs.version }}-${{ matrix.arch }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   merge-manifest:
     runs-on: ubuntu-latest
-    needs: [ check-release, amd64, aarch64 ]
+    needs: [check-release, build-push]
     if: needs.check-release.outputs.should_build == 'true'
     permissions:
       contents: read


### PR DESCRIPTION
# Background
The workflow previously maintained separate jobs for `amd64` and `arm64` builds. The `arm64` build relied on a self-hosted runner, increasing maintenance overhead.

To make the workflow code more maintainable, the workflow is updated to use matrix builds and GitHub-hosted runners for both architectures.

# Changes
- `.github/workflows/build-minio.yml`
    - Replaced separate `amd64` and `arm64` jobs with a unified matrix-based `build-push` job.
    - The `arm64` version of the job uses `ubuntu-24.04-arm` runner
    - Updated the `actions/checkout` from v4 -> v5 while doing these changes

# Testing
- [x] Triggered the workflow manually to confirm both the builds run successfully using matrix builds at https://github.com/whyredfire/minio/actions/runs/18807803537.